### PR TITLE
move commands enum closer to Cli

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,12 +108,10 @@ mod tests {
 
         pub fn execute_with_args(config: Config, _temp_dir: TempDir, args: Vec<&str>) -> ExitCode {
             let cli = Self::try_parse_from(args).unwrap();
-            match &cli.command {
-                Some(cmd) => cmd.execute(config),
-                None => {
-                    println!("Use --help for usage information");
-                    ExitCode::InvalidArguments
-                }
+            match cli.command {
+                Commands::Add(cmd) => cmd.execute(config),
+                Commands::Remove(cmd) => cmd.execute(config),
+                Commands::List(cmd) => cmd.execute(config),
             }
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,6 @@ impl Cli {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
 
     impl ShadowedArgs {
         pub fn new(args: Vec<String>) -> Self {
@@ -83,36 +82,6 @@ mod tests {
                 .collect();
 
             Self { args, is_raw }
-        }
-    }
-
-    impl Cli {
-        pub fn execute_shadowed_with_args(
-            config: Config,
-            _temp_dir: TempDir, // Add this to keep it alive
-            command: &str,
-            args: ShadowedArgs,
-        ) -> ExitCode {
-            match config
-                .aliases()
-                .find(command)
-                .map(|shadow| shadow.execute(&args.args, args.is_raw))
-            {
-                Ok(code) => code,
-                Err(e) => {
-                    eprintln!("{}", e);
-                    e.into()
-                }
-            }
-        }
-
-        pub fn execute_with_args(config: Config, _temp_dir: TempDir, args: Vec<&str>) -> ExitCode {
-            let cli = Self::try_parse_from(args).unwrap();
-            match cli.command {
-                Commands::Add(cmd) => cmd.execute(config),
-                Commands::Remove(cmd) => cmd.execute(config),
-                Commands::List(cmd) => cmd.execute(config),
-            }
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,20 +1,33 @@
-use crate::commands::Commands;
+use crate::commands::{Add, List, Remove};
 use crate::config::Config;
 use crate::error::ExitCode;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::env;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     #[command(subcommand)]
-    command: Option<Commands>,
+    command: Commands,
 }
 
 #[derive(Debug)]
 pub struct ShadowedArgs {
     args: Vec<String>,
     is_raw: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Add a new alias
+    #[command(visible_alias = "a")]
+    Add(Add),
+    /// Remove an alias
+    #[command(visible_aliases = ["rm", "delete"])]
+    Remove(Remove),
+    /// List all aliases
+    #[command(visible_alias = "ls")]
+    List(List),
 }
 
 impl ShadowedArgs {
@@ -33,12 +46,10 @@ impl ShadowedArgs {
 impl Cli {
     pub fn execute(config: Config) -> ExitCode {
         let cli = Self::parse();
-        match &cli.command {
-            Some(cmd) => cmd.execute(config),
-            None => {
-                println!("Use --help for usage information");
-                ExitCode::InvalidArguments
-            }
+        match cli.command {
+            Commands::Add(cmd) => cmd.execute(config),
+            Commands::Remove(cmd) => cmd.execute(config),
+            Commands::List(cmd) => cmd.execute(config),
         }
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,31 +2,7 @@ use crate::aliases::Alias;
 use crate::config::Config;
 use crate::error::ExitCode;
 use clap::Parser;
-use clap::Subcommand;
 use std::path::PathBuf;
-
-#[derive(Subcommand, Debug)]
-pub enum Commands {
-    /// Add a new alias
-    #[command(visible_alias = "a")]
-    Add(Add),
-    /// Remove an alias
-    #[command(visible_aliases = ["rm", "delete"])]
-    Remove(Remove),
-    /// List all aliases
-    #[command(visible_alias = "ls")]
-    List(List),
-}
-
-impl Commands {
-    pub fn execute(&self, config: Config) -> ExitCode {
-        match self {
-            Commands::Add(cmd) => cmd.execute(config),
-            Commands::Remove(cmd) => cmd.execute(config),
-            Commands::List(cmd) => cmd.execute(config),
-        }
-    }
-}
 
 #[derive(Clone, Debug, Parser)]
 pub struct Add {


### PR DESCRIPTION
Started to try and add #2, realized it was foolish -- but I liked the organization of the command matching in the cli. Every example I've seen of clap clis does this, I'm not sure why I decided to diverge from that convention.